### PR TITLE
ci: automated  macOS release dmg workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,112 @@
+name: Release DMG
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build-and-release:
+    name: Build, Sign, and Release macOS App
+    runs-on: macos-15
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Install Apple Certificate
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # Import certificate from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+
+          # Create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # Import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+          
+          # Allow xcodebuild to access the keychain without UI prompt
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+      - name: Resolve Swift package dependencies
+        run: |
+          xcodebuild \
+            -resolvePackageDependencies \
+            -project TinkerSwift.xcodeproj \
+            -scheme TinkerSwift
+
+      - name: Build and Sign
+        run: |
+          xcodebuild \
+            -project TinkerSwift.xcodeproj \
+            -scheme TinkerSwift \
+            -configuration Release \
+            -sdk macosx \
+            -derivedDataPath .build-xcode \
+            OTHER_CODE_SIGN_FLAGS="--timestamp" \
+            build
+
+      - name: Package App into DMG
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          # Prepare folder for DMG containing the App and an Applications symlink
+          mkdir -p dmg_prep
+          cp -r ".build-xcode/Build/Products/Release/TinkerSwift.app" dmg_prep/
+          ln -s /Applications dmg_prep/Applications
+          
+          # Create DMG with the proper volume name to fix the "My Great DMG 1" issue
+          hdiutil create -volname "TinkerSwift" -srcfolder dmg_prep -ov -format UDZO "TinkerSwift-${TAG_NAME}.dmg"
+          rm -rf dmg_prep
+
+      - name: Notarize DMG
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          NOTARIZATION_APPLE_ID: ${{ secrets.NOTARIZATION_APPLE_ID }}
+          NOTARIZATION_PASSWORD: ${{ secrets.NOTARIZATION_PASSWORD }}
+          NOTARIZATION_TEAM_ID: ${{ secrets.NOTARIZATION_TEAM_ID }}
+        run: |
+          # Store credentials into notarytool
+          xcrun notarytool store-credentials "TinkerSwiftNotarization" \
+             --apple-id "$NOTARIZATION_APPLE_ID" \
+             --password "$NOTARIZATION_PASSWORD" \
+             --team-id "$NOTARIZATION_TEAM_ID"
+            
+          # Submit the DMG for notarization and wait for the result
+          xcrun notarytool submit "TinkerSwift-${TAG_NAME}.dmg" \
+            --keychain-profile "TinkerSwiftNotarization" \
+            --wait
+            
+          # Staple the ticket directly to the DMG
+          xcrun stapler staple "TinkerSwift-${TAG_NAME}.dmg"
+
+      - name: Get Release Data
+        id: get_release
+        uses: joutvhu/get-release@v1
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload DMG to Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: "TinkerSwift-${{ github.event.release.tag_name }}.dmg"
+          tag_name: ${{ github.event.release.tag_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a new GitHub actions workflow `release.yml` to automatically build, package, sign and notarize `.dmg` binaries when a new GitHub Release is created.

### Features
* Resolves `tinkerswift-X.X.X.dmg` correctly based on the exact tag being released natively, mitigating bash injection errors via GitHub runner scope variables.
* Incorporates macOS native code signing commands (`security`, `xcrun notarytool`) using `.p12` certificates stored inside GitHub secrets.
* Builds the DMG securely through Apple `hdiutil` tools with a human-readable mounted volume title `TinkerSwift` instead of arbitrary dmg mount names. 

### Notes
To activate this workflow on the parent repo:
Add the following secrets to GitHub: `BUILD_CERTIFICATE_BASE64`, `P12_PASSWORD`, `NOTARIZATION_APPLE_ID`, `NOTARIZATION_TEAM_ID`, and `NOTARIZATION_PASSWORD`.
